### PR TITLE
Transient rendering (basic) done

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ This renderer is implemented based on **MY OWN** understanding of path tracing a
 Here are the features I currently implemented and supports:
 
 - A direct component renderer: a interactive visualizer for direct illumination visualization
-- A unidirectional / bidirectional Monte-Carlo MIS path tracer: supports as many bounce times as you wish, and the rendering process is based on Taichi Lang, therefore it can be very fast (not on the first run, the first run of a scene might take a long time due to taichi function inlining, especially for BDPT). The figures displayed above can be rendered within 15-20s (with cuda-backend, GPU supported). The rendering result is displayed incrementally, or maximum iteration number can be pre-set.
-- Volumetric path tracer that supports uni/bidirectional path tracing in both bounded and unbounded condition
+- A **unidirectional / bidirectional Monte-Carlo MIS path tracer**: supports as many bounce times as you wish, and the rendering process is based on Taichi Lang, therefore it can be very fast (not on the first run, the first run of a scene might take a long time due to taichi function inlining, especially for BDPT). The figures displayed above can be rendered within 15-20s (with cuda-backend, GPU supported). The rendering result is displayed incrementally, or maximum iteration number can be pre-set.
+- **Volumetric path tracer** that supports uni/bidirectional path tracing in both bounded and unbounded condition
+- A **transient renderer** with which you can visualize the propagation of the global radiance.
 - Global / indirect illumination & Ability to handle simple caustics
 - BRDFs: `Lambertian`, `Modified Phong` (Lafortune and Willems 1994), `Fresnel Blend` (Ashikhmin and Shirley 2002), `Blinn-Phong`, `Mirror-specular`.
 - BSDFs (with medium): deterministic refractive (glass-like)
 - mitusba-like XML scene file definition, supports mesh (from wavefront `.obj` file) and analytical sphere.
 - scene visualizer: which visualizes the scene you are going to render, helping to set some parameters like the relative position and camera pose
-- Extremely easy to use, with detailed comments and a passionate maintainer (yes, I myself). Therefore you can play with it with almost no cost (like compiling, environment settings blahblahblah...)
+- Extremely easy to use and multi-platform / backend (thanks to Taichi), with detailed comments and a passionate maintainer (yes, I myself). Therefore you can play with it with almost no cost (like compiling, environment settings blahblahblah...)
 
 BTW, I am just a starter in CG (ray-tracing stuffs) and Taichi Lang, so there WILL BE BUGS or some design that's not reasonable inside of my code. Also, I haven't review and done extensive profiling & optimization of the code, therefore again --- correctness is not guaranteed! But, feel free to send issue / pull-request to me if you are interested.
 

--- a/bxdf/medium.py
+++ b/bxdf/medium.py
@@ -48,7 +48,7 @@ class Medium_np:
                         self.__setattr__(name, query_func(tag_elem))
         else:
             if not is_world:
-                print("Warning: default initialization yields <transparent>, which is a trivial medium.")
+                print("[Warning] default initialization yields <transparent>, which is a trivial medium.")
         self.u_e = self.u_a + self.u_s
     
     def export(self):

--- a/emitters/abtract_source.py
+++ b/emitters/abtract_source.py
@@ -34,7 +34,8 @@ class TaichiSource:
     bool_bits:  int      # indicate whether the source is a delta source / inside free space
     intensity:  vec3
     pos:        vec3
-    inv_area:   float      # inverse area (for non-point emitters, like rect-area or mesh attached emitters)
+    inv_area:   float   # inverse area (for non-point emitters, like rect-area or mesh attached emitters)
+    emit_time:  float   # used in transient rendering: when does this emitter start to emit
 
     @ti.func
     def is_delta_pos(self):             # 0-th bits
@@ -191,12 +192,13 @@ class LightSource:
                 elif name == "scaler":
                     self.intensity *= rgb_parse(rgb_elem)
         else:
-            print("Warning: default intializer should only be used in testing.")
+            print("[Warning] default intializer should only be used in testing.")
         self.type: str = base_elem.get("type")
         self.id:   str = base_elem.get("id")
         self.inv_area  = 1.0        # inverse area (for non-point emitters, like rect-area or mesh attached emitters)
         self.attached  = False      # Indicated whether the light source is attached to an object (if True, new sampling strategy should be used)
         self.in_free_space = True   # Whether the light source itself is in free space
+        self.emit_time = 0.0
         bool_elem = base_elem.find("boolean")
         if bool_elem is not None and bool_elem.get("value").lower() == "false":
             # TODO: note that, if world has scattering medium, all the source are in the scattering medium, unless specified

--- a/emitters/area.py
+++ b/emitters/area.py
@@ -26,5 +26,5 @@ class AreaSource(LightSource):
 
     def export(self) -> TaichiSource:
         bool_bits = (self.in_free_space << 4) | 0x04
-        return TaichiSource(_type = 1, bool_bits = bool_bits, intensity = vec3(self.intensity), inv_area = self.inv_area)
+        return TaichiSource(_type = 1, bool_bits = bool_bits, intensity = vec3(self.intensity), inv_area = self.inv_area, emit_time = self.emit_time)
         

--- a/emitters/point.py
+++ b/emitters/point.py
@@ -25,4 +25,4 @@ class PointSource(LightSource):
 
     def export(self) -> TaichiSource:
         bool_bits = 0x21 + (self.in_free_space << 4)        # position delta (0x01), delta vertex (0x20)
-        return TaichiSource(_type = 0, intensity = vec3(self.intensity), pos = vec3(self.pos), bool_bits = bool_bits)
+        return TaichiSource(_type = 0, intensity = vec3(self.intensity), pos = vec3(self.pos), bool_bits = bool_bits, emit_time = self.emit_time)

--- a/inputs/trans/cbox-point.xml
+++ b/inputs/trans/cbox-point.xml
@@ -8,8 +8,8 @@
 		<float name="near_clip" value="0.001"/>
 		<float name="far_clip" value="2000"/>
 		<float name="fov" value="39.3077"/>
-        <integer name="max_bounce" value="1"/>
-        <integer name="num_shadow_ray" value="4"/>       
+        <integer name="max_bounce" value="12"/>
+        <integer name="num_shadow_ray" value="1"/>       
 
         <boolean name="use_rr" value="true"/>				<!-- Whether to use Russian roulette ray termination -->
         <boolean name="anti_alias" value="true"/>       	
@@ -19,7 +19,7 @@
 		<!-- Transient rendering configuration -->
         <string name="decomposition" value="transient_cam"/>	<!-- Decomposition mode -->				
         <integer name="sample_count" value="200"/>			<!-- Number of bins -->
-        <float name="min_time" value="0."/>					<!-- Starting time for camera -->				
+        <float name="min_time" value="0.0"/>					<!-- Starting time for camera -->				
         <float name="interval" value="0.2"/>				<!-- Width of a time bin -->			
 		<!-- End of Transient rendering configuration -->
 		
@@ -58,15 +58,9 @@
 		<rgb name="k_s" value="0.0"/>
 	</brdf>
 
-	<brdf type="lambertian" id="light">
-		<rgb name="k_d" value="#555555"/>
-		<rgb name="k_g" value="1.0"/>
-		<rgb name="k_s" value="0.0"/>
-	</brdf>
-
 	<emitter type="point" id="point">
 		<rgb name="emission" value="60.0, 60., 60.0"/>
-		<rgb name="scaler" value="1."/>
+		<rgb name="scaler" value="3.5"/>
 		<point name="center" x="2.78" y="2.73" z="-8.01"/>
 	</emitter>
 

--- a/inputs/trans/cbox-point.xml
+++ b/inputs/trans/cbox-point.xml
@@ -1,0 +1,128 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!-- A test file for mitsuba-like scene xml file parser -->
+<!-- Author: Qianyue He / Original credit goes to Wenzel Jakob -->
+<!-- Only Steady state rendering are supported -->
+<!-- Only RGB or rgb spectrums are supported -->
+<scene version="1.1">
+	<sensor type="perspective">
+		<float name="near_clip" value="0.001"/>
+		<float name="far_clip" value="2000"/>
+		<float name="fov" value="39.3077"/>
+        <integer name="max_bounce" value="1"/>
+        <integer name="num_shadow_ray" value="4"/>       
+
+        <boolean name="use_rr" value="true"/>				<!-- Whether to use Russian roulette ray termination -->
+        <boolean name="anti_alias" value="true"/>       	
+        <boolean name="stratified_sampling" value="true"/>	<!-- TODO: stratified sampling only implemented for pixel sampling -->
+        <boolean name="use_mis" value="true"/>				<!-- Whether to use multiple importance sampling -->
+
+		<!-- Transient rendering configuration -->
+        <string name="decomposition" value="transient_cam"/>	<!-- Decomposition mode -->				
+        <integer name="sample_count" value="200"/>			<!-- Number of bins -->
+        <float name="min_time" value="0."/>					<!-- Starting time for camera -->				
+        <float name="interval" value="0.2"/>				<!-- Width of a time bin -->			
+		<!-- End of Transient rendering configuration -->
+		
+		<transform name="toWorld">
+			<lookat target="2.78, 2.73, -7.99" origin="2.78, 2.73, -8.00" up="0, 1, 0"/>
+		</transform>
+
+		<film type="film">
+			<integer name="width" value="512"/>
+			<integer name="height" value="512"/>
+			<integer name="sub_samples" value="8"/>
+		</film>
+	</sensor>
+
+	<brdf type="lambertian" id="box">
+		<rgb name="k_d" value="#BCBCBC"/>
+		<rgb name="k_g" value="1.0"/>
+		<rgb name="k_s" value="0.0"/>
+	</brdf>
+
+	<brdf type="lambertian" id="white">
+		<rgb name="k_d" value="#BDBDBD"/>
+		<rgb name="k_g" value="1.0"/>
+		<rgb name="k_s" value="0.0"/>
+	</brdf>
+
+	<brdf type="lambertian" id="left_wall">
+		<rgb name="k_d" value="#DD2525"/>
+		<rgb name="k_g" value="1.0"/>
+		<rgb name="k_s" value="0.0"/>
+	</brdf>
+
+	<brdf type="lambertian" id="right_wall">
+		<rgb name="k_d" value="#25DD25"/>
+		<rgb name="k_g" value="1.0"/>
+		<rgb name="k_s" value="0.0"/>
+	</brdf>
+
+	<brdf type="lambertian" id="light">
+		<rgb name="k_d" value="#555555"/>
+		<rgb name="k_g" value="1.0"/>
+		<rgb name="k_s" value="0.0"/>
+	</brdf>
+
+	<emitter type="point" id="point">
+		<rgb name="emission" value="60.0, 60., 60.0"/>
+		<rgb name="scaler" value="1."/>
+		<point name="center" x="2.78" y="2.73" z="-8.01"/>
+	</emitter>
+
+	<shape type="obj">
+		<string name="filename" value="../meshes/cornell/cbox_floor.obj"/>
+		<ref type="material" id="white"/>
+		<transform name="toWorld">
+			<translate x="0" y="0.0" z="0"/>
+		</transform>
+	</shape>
+
+	<shape type="obj">
+		<string name="filename" value="../meshes/cornell/cbox_ceiling.obj"/>
+		<ref type="material" id="white"/>
+	</shape>
+
+	<shape type="obj">
+		<string name="filename" value="../meshes/cornell/cbox_back.obj"/>
+		<ref type="material" id="white"/>
+	</shape>
+
+	<shape type="obj">
+		<string name="filename" value="../meshes/cornell/cbox_greenwall.obj"/>
+		<ref type="material" id="right_wall"/>
+	</shape>
+
+	<shape type="obj">
+		<string name="filename" value="../meshes/cornell/cbox_redwall.obj"/>
+
+		<ref type="material" id="left_wall"/>
+	</shape>
+
+	<shape type="obj">
+		<string name="filename" value="../meshes/cornell/cbox_smallbox.obj"/>
+		<transform name="toWorld">
+			<rotate type="euler" r="0.0" p="0.0" y="0"/>
+		</transform>
+		<ref type="material" id="box"/>
+	</shape>
+
+	<shape type="obj">
+		<string name="filename" value="../meshes/cornell/cbox_largebox.obj"/>
+		<transform name="toWorld">
+			<rotate type="euler" r="0.0" p="0.0" y="-0"/>
+		</transform>
+		<ref type="material" id="box"/>
+	</shape>
+
+	<world name="yes!">
+		<rgb name="skybox" value="0.0"/>
+		<rgb name="ambient" value="0.0"/>
+		<medium type="transparent">
+			<rgb name="u_a" value="0.0"/>
+			<rgb name="u_s" value="0.0"/>
+			<rgb name="par" value="0.0"/>
+			<float name="ior" value="1.0"/>
+		</medium>
+	</world>
+</scene>

--- a/renderer/constants.py
+++ b/renderer/constants.py
@@ -19,6 +19,10 @@ VERTEX_NULL    = -1     # dummpy uninitialized vertex
 
 ON_SURFACE = 1          # whether on surface
 
+STEADY_STATE    = 0
+TRANSIENT_CAM   = 1
+TRANSIENT_LIT   = 2
+
 # =============== Math constants ================
 INV_PI = 1. / pi
 INV_2PI = INV_PI * 0.5

--- a/scene/xml_parser.py
+++ b/scene/xml_parser.py
@@ -121,14 +121,14 @@ def parse_bxdf(bxdf_list: List[xet.Element]):
         else:
             bxdf = BSDF_np(bxdf_node)
         if bxdf_id in results:
-            print(f"Warning: BXDF {bxdf_id} re-defined in XML file. Overwriting the existing BXDF.")
+            print(f"[Warning] BXDF {bxdf_id} re-defined in XML file. Overwriting the existing BXDF.")
         results[bxdf_id] = bxdf
     return results
 
 def parse_world(world_elem: xet.Element):
     world = World_np(world_elem)
     if world_elem is None:
-        print("Warning: world element not found in xml file. Using default world settings:")
+        print("[Warning] world element not found in xml file. Using default world settings:")
         print(world)
     return world
 

--- a/tracer/path_tracer.py
+++ b/tracer/path_tracer.py
@@ -156,6 +156,14 @@ class PathTracer(TracerBase):
         return pdf
     
     @ti.func
+    def get_ior(self, idx: int, in_free_space: int):
+        ior = 1.
+        if in_free_space: ior = self.world.medium.ior
+        else: 
+            if idx >= 0: ior = self.bsdf_field[idx].medium.ior
+        return ior
+    
+    @ti.func
     def is_delta(self, idx: int):
         is_delta = False
         if idx >= 0:

--- a/tracer/tracer_base.py
+++ b/tracer/tracer_base.py
@@ -31,7 +31,6 @@ class TracerBase:
     def __init__(self, objects: List[ObjDescriptor], prop: dict):
         self.w          = prop['film']['width']                              # image is a standard square
         self.h          = prop['film']['height']
-        self.sample_cnt = prop['sample_count']
         self.max_bounce = prop['max_bounce']
         self.use_rr     = prop['use_rr']
 
@@ -71,7 +70,7 @@ class TracerBase:
         """
             For debug purpose
         """
-        return f"tracer_base: number of object {self.num_objects}, w, h: ({self.w}, {self.h}), sample count: {self.sample_cnt}. Focal: {self.focal}"
+        return f"tracer_base: number of object {self.num_objects}, w, h: ({self.w}, {self.h}). Focal: {self.focal}"
 
     def initialze(self, _objects: List[ObjDescriptor]):
         pass


### PR DESCRIPTION
Transient rendering based on the basic histogram method is done. For temporal caustics positions, the algorithm is not so robust (with some shot noise, but yes, tolerable). The issue mentioned in #5 is resolved by simply setting the zero-weighted path length to zero to avoid their unnecessary blending.

This transient renderer can be further extended with the method of Jarabo 2014.